### PR TITLE
Fix Docker Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There are many easy ways to [download and run a MeiliSearch instance](https://do
 
 For example, if you use Docker:
 ```bash
-$ docker run -it --rm -p 7700:7700 getmeili/meilisearch:latest --master-key=masterKey
+$ docker run -it --rm -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey
 ```
 
 NB: you can also download MeiliSearch from **Homebrew** or **APT**.


### PR DESCRIPTION
In order to properly pass the environment variable into the container, we need to preface it with the executable script.