### PR TITLE
fix mapIds method

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -156,6 +156,10 @@ class MeilisearchEngine extends Engine
      */
     public function mapIds($results)
     {
+        if (count($results['hits']) === 0) {
+            return collect();
+        }
+
         $hits = collect($results['hits']);
         $key = key($hits->first());
 

--- a/tests/MeilisearchEngineTest.php
+++ b/tests/MeilisearchEngineTest.php
@@ -62,6 +62,19 @@ class MeilisearchEngineTest extends TestCase
     }
 
     /** @test */
+    public function mapIds_returns_empty_collection_if_no_hits()
+    {
+        $client = m::mock(Client::class);
+        $engine = new MeilisearchEngine($client);
+
+        $results = $engine->mapIds([
+            'nbHits' => 0, 'hits' => [],
+        ]);
+
+        $this->assertEquals(0, count($results));
+    }
+
+    /** @test */
     public function map_correctly_maps_results_to_models()
     {
         $client = m::mock(Client::class);


### PR DESCRIPTION
`mapIds` method should return an empty collection if no hits otherwise it will thrown an exception