### PR TITLE
Replace v1 into v2 in GHA checkout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Validate composer.json and composer.lock
       run: composer validate
     - name: Install dependencies


### PR DESCRIPTION
Should fix CI errors on #13 and #12.
If it won't, at least it updates the CI.