### PR TITLE
Update meilisearch-php to v0.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ phpunit.xml
 .phpunit.result.cache
 .php_cs.cache
 .DS_Store
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ phpunit.xml
 .phpunit.result.cache
 .php_cs.cache
 .DS_Store
-/.idea

--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@
 $ composer require meilisearch/meilisearch-laravel-scout
 ```
 
+### HTTP Client
+
+You could use any [PSR-18](https://www.php-fig.org/psr/psr-18/) compatible client to use with this SDK. No additional configurations required.<br>
+A list of compatible HTTP clients and client adapters can be found at [php-http.org](http://docs.php-http.org/en/latest/clients.html).
+
+If you use **Laravel 8** you can skip this section as laravel pre-install Guzzle 7 by default.
+
+Guzzle 6:
+
+```bash
+$ composer require php-http/guzzle6-adapter
+```
+
+Symfony Http Client:
+
+```bash
+$ composer require symfony/http-client nyholm/psr7
+```
+
+Curl:
+
+```bash
+$ composer require php-http/curl-client nyholm/psr7
+```
+
 ### Export configuration
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ composer require meilisearch/meilisearch-laravel-scout
 
 ### HTTP Client
 
-You could use any [PSR-18](https://www.php-fig.org/psr/psr-18/) compatible client to use with this SDK. No additional configurations required.<br>
+You could use any [PSR-18](https://www.php-fig.org/psr/psr-18/) compatible client to use with this SDK. No additional configurations are required.<br>
 A list of compatible HTTP clients and client adapters can be found at [php-http.org](http://docs.php-http.org/en/latest/clients.html).
 
 If you use **Laravel 8** you can skip this section as laravel pre-install Guzzle 7 by default.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ A list of compatible HTTP clients and client adapters can be found at [php-http.
 
 If you use **Laravel 8** you can skip this section as laravel pre-install Guzzle 7 by default.
 
+Guzzle 7:
+```bash
+$ composer require guzzlehttp/guzzle
+```
+If you already have guzzle installed with a version < 7, don't forget to update the version inside your composer.json
+```json
+"require": {
+  "guzzlehttp/guzzle": "^7.0"
+}
+```
+
 Guzzle 6:
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "require": {
         "php": "^7.2.5",
         "laravel/scout": "^8.0",
-        "meilisearch/meilisearch-php": "^0.14"
+        "meilisearch/meilisearch-php": "^0.14",
+        "http-interop/http-factory-guzzle": "^1.0"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.2.5",
         "laravel/scout": "^8.0",
-        "meilisearch/meilisearch-php": "^0.13"
+        "meilisearch/meilisearch-php": "^0.14"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0 || ^6.0",


### PR DESCRIPTION
Updated the `meilisearch-php` dependency to [v0.14.0](https://github.com/meilisearch/meilisearch-php/releases/tag/v0.14.0). This fixes any locked dependency issues with guzzle 6 to allow any psr18 compatible HTTP client to be used instead.

This will fix #43.

As Laravel comes with Guzzle out the box, we do not need to require the additional installation of the following dependencies `php-http/guzzle6-adapter:^2.0`