### PR TITLE
Cast $perPage to int value

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -103,7 +103,7 @@ class MeilisearchEngine extends Engine
     {
         return $this->performSearch($builder, array_filter([
             'filters' => $this->filters($builder),
-            'limit' => (int)$perPage,
+            'limit' => (int) $perPage,
             'offset' => ($page - 1) * $perPage,
         ]));
     }

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -103,7 +103,7 @@ class MeilisearchEngine extends Engine
     {
         return $this->performSearch($builder, array_filter([
             'filters' => $this->filters($builder),
-            'limit' => $perPage,
+            'limit' => (int)$perPage,
             'offset' => ($page - 1) * $perPage,
         ]));
     }


### PR DESCRIPTION
Meilisearch will not accept a string here as I found out with my app :).  If you pass a numeric string value to the algolia driver, or just to laravel's default paginator, they both work.  This will keep this behavior consistent when using this driver.