### PR TITLE
Update meilisearch-php

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,7 @@ class BookController extends Controller
 
 ## Compatibility with MeiliSearch
 
-This package is compatible with the following MeiliSearch versions:
-- `v0.13.X`
+This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
 
 ## Additional notes
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.2.5",
         "laravel/scout": "^8.0",
-        "meilisearch/meilisearch-php": "^0.14",
+        "meilisearch/meilisearch-php": "^0.15",
         "http-interop/http-factory-guzzle": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Here is the new release with 2 breaking changes: https://github.com/meilisearch/meilisearch-php/releases/tag/v0.15.0
Tell me if it's ok for you @shokme 🙂