### PR TITLE
Add config file comments/documentation

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -1,6 +1,38 @@
 <?php
 
 return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | MeiliSearch Host Address
+    |--------------------------------------------------------------------------
+    |
+    | This value is used to connect to your MeiliSearch instance. It should
+    | include the HTTP address and binding that the server is listening on.
+    |
+    | For more information on the host address, check out the MeiliSearch
+    | documentation here:
+    | https://docs.meilisearch.com/guides/advanced_guides/configuration.html
+    |
+    */
+
     'host' => env('MEILISEARCH_HOST', 'http://localhost:7700'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | MeiliSearch Master Key
+    |--------------------------------------------------------------------------
+    |
+    | This value is used to authenticate with your MeiliSearch instance. During
+    | development this is not required, but it MUST be set during a production
+    | environemtn.
+    |
+    | For more information on the master key, check out the MeiliSearch
+    | documentation here:
+    | https://docs.meilisearch.com/guides/advanced_guides/configuration.html
+    |
+    */
+
     'key' => env('MEILISEARCH_KEY', null),
+
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -25,7 +25,7 @@ return [
     |
     | This value is used to authenticate with your MeiliSearch instance. During
     | development this is not required, but it MUST be set during a production
-    | environemtn.
+    | environment.
     |
     | For more information on the master key, check out the MeiliSearch
     | documentation here:


### PR DESCRIPTION
This PR is a non-breaking change and is more of a nice to have. Most of the default Laravel config files come with an explanation for each value. This makes it easier to know exactly what the value is used for and so the user doesn't have to check the documentation every time.

I've added some basic documentation to the config file that gets published (if the user chooses to).