### PR TITLE
Fix getTotalCount() method

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -195,7 +195,7 @@ class MeilisearchEngine extends Engine
      */
     public function getTotalCount($results)
     {
-        return $results['nbHits'];
+        return count($results['hits']);
     }
 
     /**

--- a/tests/MeilisearchEngineTest.php
+++ b/tests/MeilisearchEngineTest.php
@@ -69,7 +69,7 @@ class MeilisearchEngineTest extends TestCase
         $engine = new MeilisearchEngine($client);
 
         $results = $engine->mapIds([
-            'nbHits' => 0, 'hits' => [],
+            'hits' => [],
         ]);
 
         $this->assertEquals(0, count($results));
@@ -87,7 +87,7 @@ class MeilisearchEngineTest extends TestCase
         $builder = m::mock(Builder::class);
 
         $results = $engine->map($builder, [
-            'nbHits' => 1, 'hits' => [
+            'hits' => [
                 ['id' => 1],
             ],
         ], $model);
@@ -113,7 +113,7 @@ class MeilisearchEngineTest extends TestCase
         $builder = m::mock(Builder::class);
 
         $results = $engine->map($builder, [
-            'nbHits' => 4, 'hits' => [
+            'hits' => [
                 ['id' => 1],
                 ['id' => 2],
                 ['id' => 4],


### PR DESCRIPTION
Remove `nbHits` usage because this is not reliable information.

The Meili team is aware of this. Here are the different issues and comments about it to explain why it's confusing, and why we should not use it:
- https://github.com/meilisearch/MeiliSearch/issues/1120
- https://github.com/meilisearch/documentation/issues/561
- https://github.com/meilisearch/meilisearch-php/issues/119#issuecomment-732908568

TLDR;
`nbHits` is not reliable for pagination because can be exhaustive or not, depending on the value of `exhaustiveNbHits` that MeiliSearch returns which is always `false` for the moment.

We are sorry for this. We all hope this confusion will be fixed asap in MeiliSearch.

⚠️ The linter error in the CI will be fixed with #82  