### PR TITLE
Add IndexCreated event when a new index is created

### DIFF
--- a/src/Console/IndexMeilisearch.php
+++ b/src/Console/IndexMeilisearch.php
@@ -5,6 +5,7 @@ namespace Meilisearch\Scout\Console;
 use Illuminate\Console\Command;
 use MeiliSearch\Client;
 use MeiliSearch\Exceptions\HTTPRequestException;
+use Meilisearch\Scout\Events\IndexCreated;
 
 class IndexMeilisearch extends Command
 {
@@ -45,10 +46,13 @@ class IndexMeilisearch extends Command
             if ($this->option('key')) {
                 $creation_options = ['primaryKey' => $this->option('key')];
             }
-            $client->createIndex(
+            $index = $client->createIndex(
                 $this->argument('name'),
                 $creation_options
             );
+
+            IndexCreated::dispatch($index);
+
             $this->info('Index "'.$this->argument('name').'" created.');
         } catch (HTTPRequestException $exception) {
             $this->error($exception->getMessage());

--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -58,7 +58,7 @@ class MeilisearchEngine extends Engine
         $index = $this->meilisearch->getOrCreateIndex($models->first()->searchableAs(), ['primaryKey' => $models->first()->getKeyName()]);
 
         if ($indexShouldBeCreated) {
-            IndexCreated::dispatch($index);
+            IndexCreated::dispatch($index, get_class($models->first()));
         }
 
         if ($this->usesSoftDelete($models->first()) && $this->softDelete) {

--- a/src/Events/IndexCreated.php
+++ b/src/Events/IndexCreated.php
@@ -16,8 +16,16 @@ class IndexCreated
      */
     public $index;
 
-    public function __construct(Indexes $index)
+    /**
+     * The model name if created via a Serachable Model.
+     *
+     * @var string
+     */
+    public $model;
+
+    public function __construct(Indexes $index, string $model = null)
     {
         $this->index = $index;
+        $this->model = $model;
     }
 }

--- a/src/Events/IndexCreated.php
+++ b/src/Events/IndexCreated.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Meilisearch\Scout\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use MeiliSearch\Endpoints\Indexes;
+
+class IndexCreated
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * @var Indexes
+     */
+    public $index;
+
+    public function __construct(Indexes $index)
+    {
+        $this->index = $index;
+    }
+}

--- a/tests/MeilisearchEngineTest.php
+++ b/tests/MeilisearchEngineTest.php
@@ -212,6 +212,7 @@ class MeilisearchEngineTest extends TestCase
     public function updateEmptySearchableArrayFromSoftDeletedModelDoesNotAddObjectsToIndex()
     {
         $client = m::mock(Client::class);
+        $client->shouldReceive('getIndex')->with('table')->andReturn(m::mock(Indexes::class));
         $client->shouldReceive('getOrCreateIndex')->with('table', ['primaryKey' => 'id'])->andReturn(m::mock(Indexes::class));
         $client->shouldReceive('index')->with('table')->andReturn($index = m::mock(Indexes::class));
         $index->shouldNotReceive('addDocuments');

--- a/tests/MeilisearchEngineTest.php
+++ b/tests/MeilisearchEngineTest.php
@@ -208,7 +208,9 @@ class MeilisearchEngineTest extends TestCase
         Event::fake();
         $engine = new MeilisearchEngine($client);
         $engine->update(Collection::make([new CustomKeySearchableModel()]));
-        Event::assertDispatched(IndexCreated::class);
+        Event::assertDispatched(function (IndexCreated $event) use ($index) {
+            return $event->index === $index && CustomKeySearchableModel::class === $event->model;
+        });
     }
 }
 


### PR DESCRIPTION
This adds the possibility to update a index when it is created. 

It is helpful e.g. when you have a model with fields that are essential for an output to work but not all fields should be searchable.

[Searchable Fields](https://docs.meilisearch.com/guides/advanced_guides/field_properties.html#searchable-fields)

A listener could then check the passed model or index name and if there exists another method on the model with the information about e.g. `displayFields`, then the index can be updated accordingly

E.g.:

```php
class Model
{
    public function toSearchableArray()
    {
        return [
            'id' => $this->id,
            'uuid' => $this->uuid,
            'name' => $this->name,
            'summary' => $this->summary,
            'created_at' => $this->created_at,
            'updated_at' => $this->updated_at,
        ];
    }
}
```