### PR TITLE
Update test classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
             "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=./.php_cs.dist --diff --show-progress=estimating --using-cache=no"
         ],
         "test": [
-            "./vendor/bin/phpunit --color tests/"
+            "./vendor/bin/phpunit --color"
         ]
     },
     "require": {

--- a/tests/MeilisearchEngineTest.php
+++ b/tests/MeilisearchEngineTest.php
@@ -13,11 +13,6 @@ use stdClass;
 
 class MeilisearchEngineTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
     /** @test */
     public function updateAddsObjectsToIndex()
     {

--- a/tests/MeilisearchEngineTest.php
+++ b/tests/MeilisearchEngineTest.php
@@ -180,6 +180,18 @@ class MeilisearchEngineTest extends TestCase
         });
         $engine->paginate($builder, $perPage, $page);
     }
+
+    /** @test */
+    public function updateEmptySearchableArrayFromSoftDeletedModelDoesNotAddObjectsToIndex()
+    {
+        $client = m::mock(Client::class);
+        $client->shouldReceive('getOrCreateIndex')->with('table', ['primaryKey' => 'id'])->andReturn(m::mock(Indexes::class));
+        $client->shouldReceive('index')->with('table')->andReturn($index = m::mock(Indexes::class));
+        $index->shouldNotReceive('addDocuments');
+
+        $engine = new MeilisearchEngine($client, true);
+        $engine->update(Collection::make([new SoftDeleteEmptySearchableModel()]));
+    }
 }
 
 class CustomKeySearchableModel extends SearchableModel
@@ -195,17 +207,6 @@ class EmptySearchableModel extends SearchableModel
     public function toSearchableArray()
     {
         return [];
-    }
-
-    /** @test */
-    public function update_empty_searchable_array_from_soft_deleted_model_does_not_add_objects_to_index()
-    {
-        $client = m::mock(Client::class);
-        $client->shouldReceive('index')->with('table')->andReturn($index = m::mock(Indexes::class));
-        $index->shouldNotReceive('addDocuments');
-
-        $engine = new MeilisearchEngine($client, true);
-        $engine->update(Collection::make([new SoftDeleteEmptySearchableModel()]));
     }
 }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,7 @@ namespace Meilisearch\Scout\Tests;
 
 use Meilisearch\Scout\MeilisearchServiceProvider;
 
-class TestCase extends \Orchestra\Testbench\TestCase
+abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
     public function setUp(): void
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,19 +6,10 @@ use Meilisearch\Scout\MeilisearchServiceProvider;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     protected function getPackageProviders($app)
     {
         return [
             MeilisearchServiceProvider::class,
         ];
-    }
-
-    protected function getEnvironmentSetUp($app)
-    {
     }
 }


### PR DESCRIPTION
This changes:

- Make base TestCase abstract so its not shown as warning because of missing test methods (See screenshot)
- Remove duplicate methods that are actually already handled by Testbench
- Remove `tests/` parameter from phpunit command as its already configured in the phpunit.xml
- Move "probably" wrong test case to the actual test class

![image](https://user-images.githubusercontent.com/10237069/106261669-28ed9100-6222-11eb-92de-54416adef898.png)