### PR TITLE
Fix SearchResult return value in custom search callable

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -5,6 +5,7 @@ namespace Meilisearch\Scout\Engines;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\Engine;
 use MeiliSearch\Client as Meilisearch;
+use MeiliSearch\Search\SearchResult;
 
 class MeilisearchEngine extends Engine
 {
@@ -120,12 +121,14 @@ class MeilisearchEngine extends Engine
         $meilisearch = $this->meilisearch->index($builder->index ?: $builder->model->searchableAs());
 
         if ($builder->callback) {
-            return call_user_func(
+            $result = call_user_func(
                 $builder->callback,
                 $meilisearch,
                 $builder->query,
                 $searchParams
             );
+
+            return $result instanceof SearchResult ? $result->getRaw() : $result;
         }
 
         return $meilisearch->rawSearch($builder->query, $searchParams);

--- a/tests/MeilisearchEngineTest.php
+++ b/tests/MeilisearchEngineTest.php
@@ -8,6 +8,7 @@ use MeiliSearch\Client;
 use MeiliSearch\Endpoints\Indexes;
 use Meilisearch\Scout\Engines\MeilisearchEngine;
 use Meilisearch\Scout\Tests\Fixtures\SearchableModel;
+use MeiliSearch\Search\SearchResult;
 use Mockery as m;
 use stdClass;
 
@@ -55,6 +56,70 @@ class MeilisearchEngineTest extends TestCase
             return $meilisearch->search($query, $options);
         });
         $engine->search($builder);
+    }
+
+    /**
+     * @test
+     */
+    public function submittingACallableSearchWithSearchMethodReturnsArray()
+    {
+        $builder = new Builder(
+            new SearchableModel(),
+            $query = 'mustang',
+            $callable = function ($meilisearch, $query, $options) {
+                $options['filters'] = 'foo=1';
+
+                return $meilisearch->search($query, $options);
+            }
+        );
+        $client = m::mock(Client::class);
+        $client->shouldReceive('index')->with('table')->andReturn($index = m::mock(Indexes::class));
+        $index->shouldReceive('search')->with($query, ['filters' => 'foo=1'])->andReturn(new SearchResult($expectedResult = [
+            'hits' => [],
+            'offset' => 0,
+            'limit' => 20,
+            'nbHits' => 0,
+            'exhaustiveNbHits' => false,
+            'processingTimeMs' => 1,
+            'query' => 'mustang',
+        ]));
+
+        $engine = new MeilisearchEngine($client);
+        $result = $engine->search($builder);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function submittingACallableSearchWithRawSearchMethodWorks()
+    {
+        $builder = new Builder(
+            new SearchableModel(),
+            $query = 'mustang',
+            $callable = function ($meilisearch, $query, $options) {
+                $options['filters'] = 'foo=1';
+
+                return $meilisearch->rawSearch($query, $options);
+            }
+        );
+        $client = m::mock(Client::class);
+        $client->shouldReceive('index')->with('table')->andReturn($index = m::mock(Indexes::class));
+        $index->shouldReceive('rawSearch')->with($query, ['filters' => 'foo=1'])->andReturn($expectedResult = [
+            'hits' => [],
+            'offset' => 0,
+            'limit' => 20,
+            'nbHits' => 0,
+            'exhaustiveNbHits' => false,
+            'processingTimeMs' => 1,
+            'query' => 'mustang',
+        ]);
+
+        $engine = new MeilisearchEngine($client);
+        $result = $engine->search($builder);
+
+        $this->assertSame($expectedResult, $result);
     }
 
     /** @test */


### PR DESCRIPTION
Attempt to fix issues from #86 and the update of the release https://github.com/meilisearch/meilisearch-php/releases/tag/v0.16.0

The `->search()` method on the `Indexes::class` is able to return either an array or an `SearchResult::class`.

Fixes #87 