### PR TITLE
Add more tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "orchestra/testbench": "^5.0 || ^6.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^9.1",
-        "friendsofphp/php-cs-fixer": "^2.16"
+        "friendsofphp/php-cs-fixer": "^2.16",
+        "guzzlehttp/guzzle": "^7.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
             "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=./.php_cs.dist --diff --show-progress=estimating --using-cache=no"
         ],
         "test": [
-            "./vendor/bin/phpunit --color"
+            "./vendor/bin/phpunit --coverage-text --color"
         ]
     },
     "require": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,4 +15,9 @@
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Console/IndexMeilisearch.php
+++ b/src/Console/IndexMeilisearch.php
@@ -13,7 +13,10 @@ class IndexMeilisearch extends Command
      *
      * @var string
      */
-    protected $signature = 'scout:index {--d|delete : Delete an existing index} {--k|key= : The name of primary key} {name : The name of the index}';
+    protected $signature = 'scout:index
+            {--d|delete : Delete an existing index}
+            {--k|key= : The name of primary key}
+            {name : The name of the index}';
 
     /**
      * The console command description.
@@ -29,10 +32,8 @@ class IndexMeilisearch extends Command
      *
      * @return void
      */
-    public function handle()
+    public function handle(Client $client)
     {
-        $client = new Client(config('meilisearch.host'), config('meilisearch.key'));
-
         try {
             if ($this->option('delete')) {
                 $client->deleteIndex($this->argument('name'));

--- a/src/MeilisearchServiceProvider.php
+++ b/src/MeilisearchServiceProvider.php
@@ -18,6 +18,10 @@ class MeilisearchServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'meilisearch');
+
+        $this->app->singleton(Client::class, function () {
+            return new Client(config('meilisearch.host'), config('meilisearch.key'));
+        });
     }
 
     /**
@@ -37,7 +41,7 @@ class MeilisearchServiceProvider extends ServiceProvider
 
         resolve(EngineManager::class)->extend('meilisearch', function () {
             return new MeilisearchEngine(
-                new Client(config('meilisearch.host'), config('meilisearch.key')),
+                resolve(Client::class),
                 config('scout.soft_delete', false)
             );
         });

--- a/tests/MeilisearchConsoleCommandTest.php
+++ b/tests/MeilisearchConsoleCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Meilisearch\Scout\Tests;
+
+use Laravel\Scout\EngineManager;
+use MeiliSearch\Client;
+use MeiliSearch\Endpoints\Indexes;
+use MeiliSearch\Exceptions\HTTPRequestException;
+use Meilisearch\Scout\Engines\MeilisearchEngine;
+use Mockery as m;
+
+class MeilisearchConsoleCommandTest extends TestCase
+{
+    /** @test */
+    public function nameArgumentIsRequired()
+    {
+        $this->expectExceptionMessage('Not enough arguments (missing: "name").');
+        $this->artisan('scout:index')
+            ->execute();
+    }
+
+    /** @test */
+    public function commandCreatesIndex()
+    {
+        $client = $this->mock(Client::class);
+        $client->expects('createIndex')->with($indexName = 'testindex', [])->andReturn(m::mock(Indexes::class));
+
+        $engineManager = $this->mock(EngineManager::class);
+        $engineManager->shouldReceive('engine')->with('meilisearch')->andReturn(new MeilisearchEngine(
+            $client
+        ));
+
+        $this->artisan('scout:index', [
+            'name' => $indexName,
+        ])
+            ->expectsOutput('Index "'.$indexName.'" created.')
+            ->assertExitCode(0)
+            ->run();
+    }
+
+    /** @test */
+    public function keyParameterSetsPrimaryKeyOption()
+    {
+        $client = $this->mock(Client::class);
+        $client
+            ->expects('createIndex')
+            ->with($indexName = 'testindex', ['primaryKey' => $testPrimaryKey = 'foobar'])
+            ->andReturn(m::mock(Indexes::class));
+
+        $engineManager = $this->mock(EngineManager::class);
+        $engineManager->shouldReceive('engine')->with('meilisearch')->andReturn(new MeilisearchEngine(
+            $client
+        ));
+
+        $this->artisan('scout:index', [
+            'name' => $indexName,
+            '--key' => $testPrimaryKey,
+        ])
+            ->expectsOutput('Index "'.$indexName.'" created.')
+            ->assertExitCode(0)
+            ->run();
+    }
+
+    /** @test */
+    public function deleteParameterDeletesIndex()
+    {
+        $client = $this->mock(Client::class);
+        $client->expects('deleteIndex')->with($indexName = 'testindex')->andReturn([]);
+
+        $engineManager = $this->mock(EngineManager::class);
+        $engineManager->shouldReceive('engine')->with('meilisearch')->andReturn(new MeilisearchEngine(
+            $client
+        ));
+
+        $this->artisan('scout:index', [
+            'name' => $indexName,
+            '--delete' => true,
+        ])
+            ->expectsOutput('Index "'.$indexName.'" deleted.')
+            ->assertExitCode(0)
+            ->run();
+    }
+
+    /** @test */
+    public function commandReturnsErrorStatusCodeOnException()
+    {
+        $client = $this->mock(Client::class);
+        $client->expects('createIndex')->andThrow(new HTTPRequestException(404, ['message' => 'Testmessage']));
+
+        $engineManager = $this->mock(EngineManager::class);
+        $engineManager->shouldReceive('engine')->with('meilisearch')->andReturn(new MeilisearchEngine($client));
+
+        $this->artisan('scout:index', [
+            'name' => 'foobar',
+        ])
+            ->assertExitCode(0)
+            ->execute();
+    }
+}

--- a/tests/MeilisearchEngineTest.php
+++ b/tests/MeilisearchEngineTest.php
@@ -4,6 +4,7 @@ namespace Meilisearch\Scout\Tests;
 
 use Illuminate\Database\Eloquent\Collection;
 use Laravel\Scout\Builder;
+use Laravel\Scout\EngineManager;
 use MeiliSearch\Client;
 use MeiliSearch\Endpoints\Indexes;
 use Meilisearch\Scout\Engines\MeilisearchEngine;
@@ -13,6 +14,14 @@ use stdClass;
 
 class MeilisearchEngineTest extends TestCase
 {
+    /** @test */
+    public function clientAndEngineCanBeResolved()
+    {
+        $this->assertInstanceOf(Client::class, resolve(Client::class));
+        $this->assertInstanceOf(EngineManager::class, resolve(EngineManager::class));
+        $this->assertInstanceOf(MeilisearchEngine::class, resolve(EngineManager::class)->engine('meilisearch'));
+    }
+
     /** @test */
     public function updateAddsObjectsToIndex()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Meilisearch\Scout\Tests;
 
+use Laravel\Scout\ScoutServiceProvider;
 use Meilisearch\Scout\MeilisearchServiceProvider;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
@@ -9,6 +10,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     protected function getPackageProviders($app)
     {
         return [
+            ScoutServiceProvider::class,
             MeilisearchServiceProvider::class,
         ];
     }


### PR DESCRIPTION
This PR adds tests for the `scout:index` command.
Furthermore this also adds the support to load the `Client::class` from the container. The client now can be resolve from anywhere in the application.