### PR TITLE
Add PHP 7.2 CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
     name: tests (php ${{ matrix.php-versions }})
     runs-on: ubuntu-latest
     steps:

--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,5 @@
 status = [
+    'tests (php 7.2)',
     'tests (php 7.3)',
     'tests (php 7.4)',
     'tests (php 8.0)',

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
         "http-interop/http-factory-guzzle": "^1.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0 || ^6.0",
-        "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^9.1",
+        "orchestra/testbench": "^5.0|^6.0",
+        "mockery/mockery": "^1.3",
+        "phpunit/phpunit": "^8.5|^9.5",
         "friendsofphp/php-cs-fixer": "^2.16",
         "guzzlehttp/guzzle": "^7.2"
     },


### PR DESCRIPTION
This adds PHP 7.2 CI tests.

The `composer.json` tells us, that the version is supported but we do not actually test this.

PS: If we want to upgrade the minimum dependency to `php:^7.3|^8.0` I would gladly do so. PHP 7.2 is not receiving any bugfixes and security fixes anymore and we would encorage the users to upgrade their stack to a supported version.