### PR TITLE
Remove getOrCreateIndex from Engine

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -44,7 +44,7 @@ class MeilisearchEngine extends Engine
             return;
         }
 
-        $index = $this->meilisearch->getOrCreateIndex($models->first()->searchableAs(), ['primaryKey' => $models->first()->getKeyName()]);
+        $index = $this->meilisearch->index($models->first()->searchableAs());
 
         if ($this->usesSoftDelete($models->first()) && $this->softDelete) {
             $models->each->pushSoftDeleteMetadata();

--- a/tests/Unit/MeilisearchEngineTest.php
+++ b/tests/Unit/MeilisearchEngineTest.php
@@ -19,11 +19,12 @@ class MeilisearchEngineTest extends TestCase
     public function updateAddsObjectsToIndex()
     {
         $client = m::mock(Client::class);
-        $client->shouldReceive('getOrCreateIndex')->with('table', ['primaryKey' => 'id'])->andReturn($index = m::mock(Indexes::class));
+        $client->shouldReceive('index')->with('table')->andReturn($index = m::mock(Indexes::class));
         $index->shouldReceive('addDocuments')->with([
             [
                 'id' => 1,
             ],
+            'id',
         ]);
 
         $engine = new MeilisearchEngine($client);
@@ -195,8 +196,8 @@ class MeilisearchEngineTest extends TestCase
     public function aModelIsIndexedWithACustomMeilisearchKey()
     {
         $client = m::mock(Client::class);
-        $client->shouldReceive('getOrCreateIndex')->with('table', ['primaryKey' => 'id'])->andReturn($index = m::mock(Indexes::class));
-        $index->shouldReceive('addDocuments')->with([['id' => 'my-meilisearch-key.1']]);
+        $client->shouldReceive('index')->with('table')->andReturn($index = m::mock(Indexes::class));
+        $index->shouldReceive('addDocuments')->with([['id' => 'my-meilisearch-key.1']], 'id');
 
         $engine = new MeilisearchEngine($client);
         $engine->update(Collection::make([new CustomKeySearchableModel()]));
@@ -214,11 +215,11 @@ class MeilisearchEngineTest extends TestCase
     }
 
     /** @test */
-    public function updateEmptySearchableArrayDoesNotAddObjectsToIndex()
+    public function updateEmptySearchableArrayDoesNotAddDocumentsToIndex()
     {
         $client = m::mock(Client::class);
-        $client->shouldReceive('getOrCreateIndex')->with('table', ['primaryKey' => 'id'])->andReturn($index = m::mock(Indexes::class));
-        $index->shouldNotReceive('addObjects');
+        $client->shouldReceive('index')->with('table')->andReturn($index = m::mock(Indexes::class));
+        $index->shouldNotReceive('addDocuments');
 
         $engine = new MeilisearchEngine($client);
         $engine->update(Collection::make([new EmptySearchableModel()]));
@@ -248,10 +249,10 @@ class MeilisearchEngineTest extends TestCase
     }
 
     /** @test */
-    public function updateEmptySearchableArrayFromSoftDeletedModelDoesNotAddObjectsToIndex()
+    public function updateEmptySearchableArrayFromSoftDeletedModelDoesNotAddDocumentsToIndex()
     {
         $client = m::mock(Client::class);
-        $client->shouldReceive('getOrCreateIndex')->with('table', ['primaryKey' => 'id'])->andReturn(m::mock(Indexes::class));
+        $client->shouldReceive('index')->with('table')->andReturn(m::mock(Indexes::class));
         $client->shouldReceive('index')->with('table')->andReturn($index = m::mock(Indexes::class));
         $index->shouldNotReceive('addDocuments');
 


### PR DESCRIPTION
For optimization purposes: indeed, MeiliSearch is now able to create the index if it does not exist when adding documents. The primary key is passed during the `addDocuments` method.

@mmachatschek or @shokme if one of you has time to take a look, it would be awesome 🙂