### PR TITLE
Use the model's getScoutKeyName instead of getKeyName for the default PK

### DIFF
--- a/src/Engines/MeilisearchEngine.php
+++ b/src/Engines/MeilisearchEngine.php
@@ -59,7 +59,7 @@ class MeilisearchEngine extends Engine
         })->filter()->values()->all();
 
         if (!empty($objects)) {
-            $index->addDocuments($objects, $models->first()->getKeyName());
+            $index->addDocuments($objects, $models->first()->getScoutKeyName());
         }
     }
 

--- a/tests/Fixtures/SearchableModel.php
+++ b/tests/Fixtures/SearchableModel.php
@@ -21,6 +21,11 @@ class SearchableModel extends Model
         return 'table';
     }
 
+    public function getScoutKeyName()
+    {
+        return 'id';
+    }
+
     public function scoutMetadata()
     {
         return [];


### PR DESCRIPTION
Currently, imported documents will use the PK of the table instead of Laravel's dedicated Scout method `getScoutKeyName`. Here is the relevant part from the [Scout docs](https://laravel.com/docs/8.x/scout#configuring-the-model-id):

> By default, Scout will use the primary key of the model as model's unique ID / key that is stored in the search index. If you need to customize this behavior, you may override the getScoutKey and the getScoutKeyName methods on the model:

This will be a breaking change because `getKeyName` does not return the same value as the default `getScoutKeyName`